### PR TITLE
seat/keyboard: optimize wlr_seat_set_keyboard to send the keymap only if it has changed

### DIFF
--- a/types/seat/wlr_seat_keyboard.c
+++ b/types/seat/wlr_seat_keyboard.c
@@ -127,6 +127,11 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat,
 		return;
 	}
 
+	// send the keymap only if it has changed
+	bool needs_keymap_update =
+		!seat->keyboard_state.keyboard || !keyboard ||
+		seat->keyboard_state.keyboard->keymap != keyboard->keymap;
+
 	if (seat->keyboard_state.keyboard) {
 		wl_list_remove(&seat->keyboard_state.keyboard_destroy.link);
 		wl_list_remove(&seat->keyboard_state.keyboard_keymap.link);
@@ -151,7 +156,9 @@ void wlr_seat_set_keyboard(struct wlr_seat *seat,
 
 		struct wlr_seat_client *client;
 		wl_list_for_each(client, &seat->clients, link) {
-			seat_client_send_keymap(client, keyboard);
+			if (needs_keymap_update) {
+				seat_client_send_keymap(client, keyboard);
+			}
 			seat_client_send_repeat_info(client, keyboard);
 		}
 


### PR DESCRIPTION
With the current implementation, when switching keyboards an Xwayland client will always invoke xkbcomp to compile a keyboard description from the passed keymap string. If the keyboards happen to share the same keymap, this generates unnecessary (and costly) work.

Note that for this to work, all keyboards need to share a common keymap, which is implemented in ValveSoftware/gamescope#1726.